### PR TITLE
Fix: warning showing on course list widget of elementor addons

### DIFF
--- a/includes/addons/CourseList.php
+++ b/includes/addons/CourseList.php
@@ -126,7 +126,7 @@ class CourseList extends BaseAddon {
 		$this->add_group_control(
 			Group_Control_Image_Size::get_type(),
 			array(
-				'name'      => 'course_list_image_size', // Actually its `image_size`.
+				'name'      => 'course_list_image_resolution', // Actually its `image_size`.
 				'label'     => __( 'Image Size', 'tutor-lms-elementor-addons' ),
 				'default'   => 'medium_large',
 				'condition' => array(

--- a/templates/course/list/grid/parts/thumbnail.php
+++ b/templates/course/list/grid/parts/thumbnail.php
@@ -1,13 +1,13 @@
-<?php if ( 'yes' == $settings['course_list_image'] ) : ?>
-    <?php
-        $image_size = $settings['course_list_image_size'];
-        $image_url  = get_tutor_course_thumbnail( $image_size, $url = true );
-    ?>
-    <div class="tutor-course-thumbnail">
-        <a href="<?php the_permalink(); ?>" class="tutor-d-block">
-            <div class="tutor-ratio tutor-ratio-<?php echo $settings['course_list_skin'] == 'overlayed' ? '16x9' : '4x3'; ?>">
-                <img class="tutor-card-image-top" src="<?php echo $image_url; ?>" alt="<?php the_title(); ?>" loading="lazy">
-            </div>
-        </a>
-    </div>
+<?php if ( 'yes' === $settings['course_list_image'] ) : ?>
+	<?php
+		$image_size = $settings['course_list_image_resolution_size'];
+		$image_url  = get_tutor_course_thumbnail( $image_size, $url = true );
+	?>
+	<div class="tutor-course-thumbnail">
+		<a href="<?php the_permalink(); ?>" class="tutor-d-block">
+			<div class="tutor-ratio tutor-ratio-<?php echo 'overlayed' === $settings['course_list_skin'] ? '16x9' : '4x3'; ?>">
+				<img class="tutor-card-image-top" src="<?php echo $image_url; ?>" alt="<?php the_title(); ?>" loading="lazy">
+			</div>
+		</a>
+	</div>
 <?php endif; ?>


### PR DESCRIPTION
### Overview

Fixed the warning that was showing on `Course List` widget of elementor addon. This was because on the settings key a '_size' prefix was getting added making the key full name `course_image_size_size` thus throwing undefined warning. To fix this I have renamed the settings key to be `course_list_image_resolution` so the full name becomes `course_list_image_resolution_size`