### PR TITLE
Fix: Lesson content not updating after updating lesson with elementor

### DIFF
--- a/classes/Template.php
+++ b/classes/Template.php
@@ -262,19 +262,19 @@ class Template {
 		$elementor_data     = json_decode( $elementor_data, true ) ?? array();
 		$lesson_description = get_post( $lesson_id )->post_content ?? '';
 
-		if ( ! count( $elementor_data ) ) {
+		if ( ! tutor_utils()->count( $elementor_data ) ) {
 			return;
 		}
 
 		$elements = $elementor_data[0]['elements'] ?? array();
 
-		if ( ! count( $elements ) ) {
+		if ( ! tutor_utils()->count( $elements ) ) {
 			return;
 		}
 
 		$settings = $elements[0]['settings'] ?? array();
 
-		if ( ! count( $settings ) || ! isset( $settings['editor'] ) ) {
+		if ( ! tutor_utils()->count( $settings ) || ! isset( $settings['editor'] ) ) {
 			return;
 		}
 

--- a/classes/Template.php
+++ b/classes/Template.php
@@ -39,6 +39,7 @@ class Template {
 		add_action( 'save_post', array( $this, 'elementor_template_new_post' ), 99, 2 );
 
 		add_action( 'template_redirect', array( $this, 'is_tutor_single_page' ) );
+		add_action( 'tutor/lesson_update/after', array( $this, 'update_tutor_lesson_content' ) );
 	}
 
 	/**
@@ -78,7 +79,7 @@ class Template {
 		return (int) $post_id;
 	}
 
-	public function single_bundle_template($template){
+	public function single_bundle_template( $template ) {
 		global $wp_query, $post;
 		if ( ! post_type_supports( 'course-bundle', 'elementor' ) ) {
 			return $template;
@@ -105,7 +106,7 @@ class Template {
 					return tutor_get_template( 'login' );
 				}
 			}
-			$template      = etlms_get_template( 'single-course-bundle' );
+			$template = etlms_get_template( 'single-course-bundle' );
 			return $template;
 		}
 		return $template;
@@ -160,7 +161,6 @@ class Template {
 	/**
 	 * sigle bundle load
 	 */
-
 	public function single_bundle_content( $post ) {
 		$document = Plugin::$instance->documents->get( $post->ID );
 
@@ -175,7 +175,8 @@ class Template {
 		} else { ?>
 			<h1><?php esc_html_e( 'Mark a page/template as Tutor Single course from Elementor Page Settings', 'tutor-lms-elementor-addons' ); ?></h1>
 			
-		<?php }
+			<?php
+		}
 	}
 
 
@@ -185,22 +186,23 @@ class Template {
 	 * @param $post
 	 * @since v.1.0.0
 	 */
-	
 	public function single_course_content( $post ) {
 		$document = Plugin::$instance->documents->get( $post->ID );
 
 		if ( $document && $document->is_built_with_elementor() ) {
-			 the_content();
+			the_content();
 			return;
 		}
 
 		$template_id = $this->template_id;
 		if ( $template_id ) {
 			echo Plugin::instance()->frontend->get_builder_content_for_display( $template_id );
-		} else { ?>
+		} else {
+			?>
 			<h1><?php esc_html_e( 'Mark a page/template as Tutor Single course from Elementor Page Settings', 'tutor-lms-elementor-addons' ); ?></h1>
 			
-		<?php }
+			<?php
+		}
 	}
 
 
@@ -247,6 +249,44 @@ class Template {
 	}
 
 	/**
+	 * Update lesson content after being edited by elementor.
+	 *
+	 * @since 3.0.2
+	 *
+	 * @param int $lesson_id the lesson id.
+	 *
+	 * @return void
+	 */
+	public function update_tutor_lesson_content( int $lesson_id = 0 ) {
+		$elementor_data     = get_post_meta( $lesson_id, '_elementor_data', true );
+		$elementor_data     = json_decode( $elementor_data, true ) ?? array();
+		$lesson_description = get_post( $lesson_id )->post_content ?? '';
+
+		if ( ! count( $elementor_data ) ) {
+			return;
+		}
+
+		$elements = $elementor_data[0]['elements'] ?? array();
+
+		if ( ! count( $elements ) ) {
+			return;
+		}
+
+		$settings = $elements[0]['settings'] ?? array();
+
+		if ( ! count( $settings ) || ! isset( $settings['editor'] ) ) {
+			return;
+		}
+
+		$elementor_data[0]['elements'][0]['settings']['editor'] = $lesson_description;
+		$updated_elementor_data                                 = json_encode( $elementor_data );
+
+		update_post_meta( $lesson_id, '_elementor_data', $updated_elementor_data );
+		delete_post_meta( $lesson_id, '_elementor_css' );
+		delete_post_meta( $lesson_id, '_elementor_element_cache' );
+	}
+
+	/**
 	 * Update template_id for single course
 	 *
 	 * @param $post_ID
@@ -257,5 +297,4 @@ class Template {
 		$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => '_tutor_lms_elementor_template_id' ) );
 		update_post_meta( $post_ID, '_tutor_lms_elementor_template_id', time() );
 	}
-
 }


### PR DESCRIPTION
### Overview

This pr fixes an issue with tutor lesson, when lessons are updated with elementor by click `Wp Editor > Elementor` the lesson description changes are not being reflected when updated the lesson again from course builder. To fix this I have utilized the hook `tutor/lesson_update/after` which is called after the lesson is updated with new description, then updated the post_meta `_elementor_data` which has a `editor` data which contains the description of the element, I have updated that. Furthermore, after updating post_meta to new value Elementor creates a cache_meta and css_meta which doesn't allow updating the content on frontend so I have removed those two meta that is generated after updating post_meta to show the changes on frontend.